### PR TITLE
Add option to exclude or include tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ SvgOptimizer.optimize_file("file.svg")
 
 # Optimize a file - it saves a copy to "optimized/file.svg".
 SvgOptimizer.optimize_file("file.svg", "optimized/file.svg")
+
+# Optimize including only specific tweaks
+# Values: :remove_comment, :remove_editor_namespace,
+#         :remove_empty_attribute, :remove_empty_container,
+#         :remove_empty_text_node, :remove_hidden_element, :remove_metadata,
+#         :remove_raster_image, :remove_unused_namespace
+optimized = SvgOptimizer.optimize(xml, with: :remove_comment)
+
+# Optimize excluding tweaks
+optimized = SvgOptimizer.optimize(xml, without: [:remove_comment, :remove_empty_attribute] )
 ```
 
 ## Contributing

--- a/lib/svg_optimizer.rb
+++ b/lib/svg_optimizer.rb
@@ -29,19 +29,40 @@ module SvgOptimizer
     RemoveEmptyContainer
   ]
 
-  def self.optimize(contents)
+  def self.optimize(contents, opts = {})
+    opts = { without: [] }.merge(opts)
+
+    normalize_opt!(opts, :with)
+    normalize_opt!(opts, :without)
+
+    selected_plugins = (opts[:with] || opts[:without]).map do |plugin_name|
+      plugin_name.to_s.capitalize.gsub(/_([a-z]{1})/){ $1.capitalize }
+    end
+
+    plugins = PLUGINS.reject do |plugin_name|
+      plugin_included = selected_plugins.include?(plugin_name)
+
+      opts[:with] ? !plugin_included : plugin_included
+    end
+
     xml = Nokogiri::XML(contents)
-    PLUGINS.each do |plugin_name|
+    plugins.each do |plugin_name|
       Plugins.const_get(plugin_name).new(xml).process
     end
 
     xml.root.to_xml
   end
 
-  def self.optimize_file(path, target = path)
-    contents = optimize(File.read(path))
+  def self.optimize_file(path, target = path, opts = {})
+    contents = optimize(File.read(path), opts)
 
     File.open(target, "w") {|file| file << contents }
     true
+  end
+
+  private
+  def self.normalize_opt!(opts, key)
+    opt = opts[key]
+    opts[key] = [opt] if opt && ( opt.is_a?(String) || opt.is_a?(Symbol) )
   end
 end

--- a/spec/svg_optimizer/svg_optimizer_spec.rb
+++ b/spec/svg_optimizer/svg_optimizer_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+describe SvgOptimizer do
+  describe ".optimize" do
+    let(:svg) do
+      RSpecHelpers::SVG % <<-SVG
+        <!-- foo -->
+        <circle r="" cx="" />
+        <g />
+        <!-- bar -->
+      SVG
+    end
+
+    it "should include all plugins by default" do
+      contents = SvgOptimizer.optimize(svg)
+      xml = Nokogiri::XML(contents)
+
+      expect(xml.xpath("//comment()")).to be_empty
+      expect(xml.xpath("//*[@*='']")).to be_empty
+      expect(xml.root.css("g")).to be_empty
+    end
+
+    it "should exclude a single plugin" do
+      contents = SvgOptimizer.optimize(svg, without: :remove_comment)
+      xml = Nokogiri::XML(contents)
+
+      expect(xml.xpath("//comment()")).not_to be_empty
+      expect(xml.xpath("//*[@*='']")).to be_empty
+      expect(xml.root.css("g")).to be_empty
+    end
+
+    it "should exclude multiple plugins" do
+      contents = SvgOptimizer.optimize(svg, without: [:remove_comment, :remove_empty_attribute] )
+      xml = Nokogiri::XML(contents)
+
+      expect(xml.xpath("//comment()")).not_to be_empty
+      expect(xml.xpath("//*[@*='']")).not_to be_empty
+      expect(xml.root.css("g")).to be_empty
+    end
+
+    it "should include a single plugins" do
+      contents = SvgOptimizer.optimize(svg, with: :remove_comment)
+      xml = Nokogiri::XML(contents)
+
+      expect(xml.xpath("//comment()")).to be_empty
+      expect(xml.xpath("//*[@*='']")).not_to be_empty
+      expect(xml.root.css("g")).not_to be_empty
+    end
+
+    it "should include multiple plugins" do
+      contents = SvgOptimizer.optimize(svg, with: [:remove_comment, :remove_empty_attribute])
+      xml = Nokogiri::XML(contents)
+
+      expect(xml.xpath("//comment()")).to be_empty
+      expect(xml.xpath("//*[@*='']")).to be_empty
+      expect(xml.root.css("g")).not_to be_empty
+    end
+  end
+end
+


### PR DESCRIPTION
I added (optional) options to allow excluding or including specific tweaks.

Include tweaks using the with option:
```ruby
# single tweak
SvgOptimizer.optimize(xml, with: :remove_comment)           

# multiple tweaks                     
SvgOptimizer.optimize(xml, with: [:remove_comment, :remove_empty_container])
```

Exclude tweaks using the without option:
```ruby
# excluding a single tweak
SvgOptimizer.optimize(xml, without: :remove_comment)

# excluding multiple tweaks
 SvgOptimizer.optimize(xml, without: [:remove_comment, :remove_empty_container])
```