### PR TITLE
Remove attributes with editor namespace.

### DIFF
--- a/lib/svg_optimizer/plugins/remove_editor_namespace.rb
+++ b/lib/svg_optimizer/plugins/remove_editor_namespace.rb
@@ -17,8 +17,27 @@ module SvgOptimizer
         http://www.bohemiancoding.com/sketch/ns
       ]
 
+      def namespaces_to_be_removed
+        xml.namespaces.map do |name, value|
+          _, name = name.split(":")
+          name if NAMESPACES.include?(value)
+        end.compact
+      end
+
+      def remove_namespaced_attributes
+        namespaces_to_be_removed.each do |ns|
+          xml.xpath("//*[@#{ns}:*]").each do |node|
+            node.attributes.each do |_, attr|
+              next unless attr.namespace
+              attr.remove if attr.namespace.prefix == ns
+            end
+          end
+        end
+      end
+
       def process
         namespaces = xml.namespaces
+        remove_namespaced_attributes
         xml.remove_namespaces!
 
         namespaces.each do |name, value|

--- a/spec/fixtures/namespaced_attribute.svg
+++ b/spec/fixtures/namespaced_attribute.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.4.4 (17248) - http://www.bohemiancoding.com/sketch -->
+    <title>Rectangle 1</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <rect id="Rectangle-1" fill="#4990E2" sketch:type="MSShapeGroup" x="0" y="0" width="25" height="25"></rect>
+    </g>
+</svg>

--- a/spec/svg_optimizer/plugins/remove_editor_namespace_spec.rb
+++ b/spec/svg_optimizer/plugins/remove_editor_namespace_spec.rb
@@ -1,8 +1,18 @@
 require "spec_helper"
 
 describe SvgOptimizer::Plugins::RemoveEditorNamespace do
-  with_svg_plugin ""
-  it { expect(xml.namespaces.values).not_to include("http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd") }
-  it { expect(xml.namespaces.values).to include("http://www.w3.org/2000/svg") }
-  it { expect(xml.namespaces.values).to include("http://www.w3.org/1999/xlink") }
+  describe "root namespaces" do
+    with_svg_plugin ""
+    it { expect(xml.namespaces.values).not_to include("http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd") }
+    it { expect(xml.namespaces.values).to include("http://www.w3.org/2000/svg") }
+    it { expect(xml.namespaces.values).to include("http://www.w3.org/1999/xlink") }
+  end
+
+  describe "attribute namespaces" do
+    with_svg_plugin "namespaced_attribute.svg"
+    it { expect(xml.css("#Page-1").first.has_attribute?("sketch:type")).to be_falsy }
+    it { expect(xml.css("#Page-1").first.has_attribute?("type")).to be_falsy }
+    it { expect(xml.css("#Rectangle-1").first.has_attribute?("sketch:type")).to be_falsy }
+    it { expect(xml.css("#Rectangle-1").first.has_attribute?("type")).to be_falsy }
+  end
 end


### PR DESCRIPTION
Since we are removing the editor's namespace from the root element, we should also remove the namespaced attributes. Otherwise we'll end up with things like `<g type="MSPage">`.