### PR TITLE
Implement InlineStyles plugin

### DIFF
--- a/lib/svg_optimizer/plugins/inline_styles.rb
+++ b/lib/svg_optimizer/plugins/inline_styles.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+begin
+  require 'css_parser'
+
+  module SvgOptimizer
+    module Plugins
+      class InlineStyles < Base
+        def process
+          xml.css("style").each do |style_node|
+            css_parser.load_string! style_node.text
+            style_node.remove
+          end
+          xml.xpath("//*[@class]").each(&method(:inline_style))
+        end
+
+        def inline_style(node)
+          style = node.classes.inject([]) do |result, class_name|
+            css_selector = ".#{class_name}"
+            result << css_parser.find_by_selector(css_selector).join(';')
+          end.compact.join(';')
+          node.set_attribute('style', style)
+          node.remove_attribute('class')
+        end
+
+        private
+
+        def css_parser
+          @css_parser ||= CssParser::Parser.new
+        end
+      end
+    end
+  end
+rescue LoadError
+  warn "To use InlineStyles plugin of SvgOptimizer, please add `gem 'css_parser'` to your Gemfile"
+end

--- a/svg_optimizer.gemspec
+++ b/svg_optimizer.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-meta"
   spec.add_development_dependency "minitest-utils"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "css_parser"
 end

--- a/test/svg_optimizer/plugins/inline_styles_test.rb
+++ b/test/svg_optimizer/plugins/inline_styles_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "svg_optimizer/plugins/inline_styles"
+
+class InlineStylesTest < Minitest::Test
+  plugin_class SvgOptimizer::Plugins::InlineStyles
+  with_svg_plugin %[<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <style>.st0{fill:red;}</style>
+  <rect width="100" height="100" class="st0" />
+</svg>]
+
+  test "inlines style" do
+    assert_equal "fill: red;", xml.at("rect").attributes['style'].value
+  end
+
+  test "removes class" do
+    assert_nil xml.at("rect").attributes['class']
+  end
+
+  test "removes style tag" do
+    assert_nil xml.at("style")
+  end
+end


### PR DESCRIPTION
I have added the proof-of-concept implementation of InlineStyles plugin.
It uses `css_parser` gem, so I don’t require this plugin by default in `svg_optimizer.rb`.

Right now it just inlines every class as style attribute without the logic of checking whether it used only once or not (so it could actually deoptimize SVG).

But it could be used as a start for implementing analog of https://github.com/svg/svgo/blob/master/plugins/inlineStyles.js.