### PR TITLE
fix: do not set Nokogiri's `noent` parse option by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ SvgOptimizer.optimize_file("file.svg")
 SvgOptimizer.optimize_file("file.svg", "optimized/file.svg")
 ```
 
+You may have a need to optimize a *trusted* SVG document with entities that need to be
+expanded. **Only if you are sure the file is trusted**, you may enable this additional entity
+processing by passing the `trusted:` keyword argument:
+
+``` ruby
+# Optimize an existing trusted String which requires entity expansion.
+xml = File.read("file.svg")
+optimized = SvgOptimizer.optimize(xml, trusted: true)
+
+# Optimize a trusted file which requires entity expansion - it will override the original file.
+SvgOptimizer.optimize_file("file.svg", trusted: true)
+```
+
+
 You can specify the plugins you want to enable. The method signature is:
 
 ```ruby

--- a/lib/svg_optimizer.rb
+++ b/lib/svg_optimizer.rb
@@ -37,9 +37,11 @@ module SvgOptimizer
     RemoveEmptyContainer
   ].map {|name| Plugins.const_get(name) }
 
-  def self.optimize(contents, plugins = DEFAULT_PLUGINS)
+  def self.optimize(contents, plugins = DEFAULT_PLUGINS, trusted: false)
     xml = Nokogiri::XML(contents) do |config|
-      config.recover.noent
+      if trusted
+        config.recover.noent
+      end
     end
 
     plugins.each {|plugin| plugin.new(xml).process }
@@ -47,8 +49,8 @@ module SvgOptimizer
     xml.root.to_xml
   end
 
-  def self.optimize_file(path, target = path, plugins = DEFAULT_PLUGINS)
-    contents = optimize(File.read(path), plugins)
+  def self.optimize_file(path, target = path, plugins = DEFAULT_PLUGINS, trusted: false)
+    contents = optimize(File.read(path), plugins, trusted: trusted)
     File.open(target, "w") {|file| file << contents }
     true
   end

--- a/test/svg_optimizer/issue_8_test.rb
+++ b/test/svg_optimizer/issue_8_test.rb
@@ -3,8 +3,35 @@
 require "test_helper"
 
 class Issue8Test < Minitest::Test
-  test "processes file" do
+  test "processes string when marked as trusted" do
     raw_svg = File.read("./test/fixtures/issue_8.svg")
-    SvgOptimizer.optimize(raw_svg)
+
+    SvgOptimizer.optimize(raw_svg, trusted: true)
+  end
+
+  test "processes file when marked as trusted" do
+    Dir.mktmpdir do |dir|
+      FileUtils.cp("./test/fixtures/issue_8.svg", dir)
+
+      SvgOptimizer.optimize_file(File.join(dir, "issue_8.svg"), trusted: true)
+    end
+  end
+
+  test "does not process string by default" do
+    raw_svg = File.read("./test/fixtures/issue_8.svg")
+
+    assert_raises(Nokogiri::XML::SyntaxError) do
+      SvgOptimizer.optimize(raw_svg)
+    end
+  end
+
+  test "does not process file by default" do
+    Dir.mktmpdir do |dir|
+      FileUtils.cp("./test/fixtures/issue_8.svg", dir)
+
+      assert_raises(Nokogiri::XML::SyntaxError) do
+        SvgOptimizer.optimize_file(File.join(dir, "issue_8.svg"))
+      end
+    end
   end
 end


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Allow users to opt into entity expansion on trusted documents by passing in the kwarg:

    trusted: true

Otherwise do not enable this option, because it's not safe for untrusted documents.


### Why

The fix introduced for #8 in b1b5013d introduces a security issue.

The [Nokogiri documentation for ParseOptions::NOENT](https://nokogiri.org/rdoc/Nokogiri/XML/ParseOptions.html) says:

> NOENT
> Substitute entities. Off by default.
> ⚠ This option enables entity substitution, contrary to what the name implies.
> ⚠ It is UNSAFE to set this option when parsing untrusted documents.

Please feel free to contact me directly at mike.dalessio@gmail.com for more information about the security impact (I'm the Nokogiri maintainer).


### Known limitations

N/A
